### PR TITLE
Upgrade test project to elm 0.18.0 version

### DIFF
--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -5,7 +5,7 @@ import Test.Runner.Node exposing (run)
 import Json.Encode exposing (Value)
 
 
-main : Program Value
+main : Test.Runner.Node.TestProgram
 main =
     run emit Tests.all
 

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,10 +9,10 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
-        "rtfeldman/node-test-runner": "2.0.0 <= v < 3.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0"
+        "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
+        "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
This allows to use the same Elm version on the test project (0.18.0) which is already used on the main project